### PR TITLE
Better option parsing

### DIFF
--- a/coinbrew
+++ b/coinbrew
@@ -107,8 +107,9 @@ function parse_args {
     do
         arg=$1
         shift
+        echo $arg
         case $arg in
-            *=*) 
+            *=*)
                 option=${arg%%=*}
                 option_arg=${arg#*=}
                 ;;
@@ -121,7 +122,6 @@ function parse_args {
                         option_arg=
                     else
                         option_arg=$1
-                        shift
                     fi
                 fi
                 ;;
@@ -142,6 +142,7 @@ function parse_args {
                             exit 3
                             ;;
                     esac
+                    shift
                 else
                     echo "No path provided for --prefix"
                     exit 3
@@ -157,6 +158,7 @@ function parse_args {
                             build_dir=$PWD/$option_arg
                             ;;
                     esac
+                    shift
                 else
                     echo "No path provided for --build-dir"
                     exit 3
@@ -165,6 +167,7 @@ function parse_args {
             -j|--parallel-jobs)
                 if [ x"$option_arg" != x ]; then
                     jobs=$option_arg
+                    shift
                 else
                     echo "No number specified for --parallel-jobs"
                     exit 3
@@ -179,6 +182,7 @@ function parse_args {
             -v|--verbosity)
                 if [ x"$option_arg" != x ]; then
                     verbosity=$option_arg
+                    shift
                 else
                     echo "No verbosity specified for --verbosity"
                     exit 3
@@ -187,6 +191,7 @@ function parse_args {
             --main-proj)
                 if [ x"$option_arg" != x ]; then
                     main_proj=$option_arg
+                    shift
                 else
                     echo "No main project specified"
                     exit 3
@@ -195,6 +200,7 @@ function parse_args {
             --main-proj-version)
                 if [ x"$option_arg" != x ]; then
                     main_proj_version=$option_arg
+                    shift
                 else
                     echo "No main project specified"
                     exit 3
@@ -203,6 +209,7 @@ function parse_args {
             -s|--skip)
                 if [ x"$option_arg" != x ]; then
                     coin_skip_projects=$option_arg
+                    shift
                 else
                     echo "No projects specified to skip"
                     exit 3

--- a/coinbrew
+++ b/coinbrew
@@ -105,13 +105,37 @@ function get_project {
 function parse_args {
     while (( "$#" ))
     do
-        case $1 in
+        arg=$1
+        shift
+        case $arg in
+            *=*) 
+                option=${arg%%=*}
+                option_arg=${arg#*=}
+                ;;
+            -*)
+                option=$arg
+                if [ "$#" = 0 ]; then
+                    option_arg=
+                else
+                    if [[ "$1" == -* ]]; then
+                        option_arg=
+                    else
+                        option_arg=$1
+                        shift
+                    fi
+                fi
+                ;;
+            *)
+                option=$arg
+                option_arg=
+                ;;
+        esac
+        case $option in
             -p|--prefix)
-                shift
-                if [[ "$1" != -* ]]; then
-                    case $1 in
+                if [ x"$option_arg" != x ]; then
+                    case $option_arg in
                         [\\/$]* | ?:[\\/]* | NONE | '' )
-                            prefix=$1
+                            prefix=$option_arg
                             ;;
                         *)  
                             echo "Prefix path must be absolute."
@@ -124,14 +148,13 @@ function parse_args {
                 fi
                 ;;
             -b|--build-dir)
-                shift
-                if [[ "$1" != -* ]]; then
-                    case $1 in
+                if [ x"$option_arg" != x ]; then
+                    case $option_arg in
                         [\\/$]* | ?:[\\/]* | NONE | '' )
-                            build_dir=$1
+                            build_dir=$option_arg
                             ;;
                         *)
-                            build_dir=$PWD/$1
+                            build_dir=$PWD/$option_arg
                             ;;
                     esac
                 else
@@ -140,9 +163,8 @@ function parse_args {
                 fi
                 ;;
             -j|--parallel-jobs)
-                shift
-                if [[ "$1" != -* ]]; then
-                    jobs=$1
+                if [ x"$option_arg" != x ]; then
+                    jobs=$option_arg
                 else
                     echo "No number specified for --parallel-jobs"
                     exit 3
@@ -155,36 +177,35 @@ function parse_args {
                 exit 3
                 ;;
             -v|--verbosity)
-                shift
-                if [[ "$1" != -* ]]; then
-                    verbosity=$1
+                if [ x"$option_arg" != x ]; then
+                    verbosity=$option_arg
                 else
                     echo "No verbosity specified for --verbosity"
                     exit 3
                 fi
                 ;;
             --main-proj)
-                shift
-                if [[ "$1" != -* ]]; then
-                    main_proj=$1
+                if [ x"$option_arg" != x ]; then
+                    main_proj=$option_arg
                 else
                     echo "No main project specified"
                     exit 3
                 fi
                 ;;
             --main-proj-version)
-                shift
-                if [[ "$1" != -* ]]; then
-                    main_proj_version=$1
+                if [ x"$option_arg" != x ]; then
+                    main_proj_version=$option_arg
                 else
                     echo "No main project specified"
                     exit 3
                 fi
                 ;;
             -s|--skip)
-                shift
-                if [[ "$1" != -* ]]; then
-                    coin_skip_projects=$1
+                if [ x"$option_arg" != x ]; then
+                    coin_skip_projects=$option_arg
+                else
+                    echo "No projects specified to skip"
+                    exit 3
                 fi
                 ;;
             -h|--help)
@@ -221,9 +242,6 @@ function parse_args {
             --skip-update)
                 skip_update=true
                 ;;
-            --*|*=*)
-                configure_options["$1"]=""
-                ;;
             fetch)
                 num_actions+=1
                 fetch=true
@@ -241,15 +259,18 @@ function parse_args {
                 uninstall=true
                 ;;
             *)
-                if [[ $1 == *:* ]]; then
-                    main_proj=`echo $1 | cut -d ':' -f 1`
-                    main_proj_version=`echo $1 | cut -d ':' -f 2`
+                if [[ "$arg" == *=* ]] || [[ "$arg" == --* ]]; then
+                    configure_options["$arg"]=""
                 else
-                    main_proj=$1
+                    if [[ $arg == *:* ]]; then
+                        main_proj=`echo $arg | cut -d ':' -f 1`
+                        main_proj_version=`echo $arg | cut -d ':' -f 2`
+                    else
+                        main_proj=$arg
+                    fi
                 fi
                 ;;
         esac
-        shift
     done
     echo
 }

--- a/coinbrew
+++ b/coinbrew
@@ -107,7 +107,7 @@ function parse_args {
     do
         echo $1
         case $1 in
-            --prefix)
+            -p|--prefix)
                 shift
                 if [[ "$1" != -* ]]; then
                     case $1 in
@@ -124,7 +124,7 @@ function parse_args {
                     exit 3
                 fi
                 ;;
-            --build-dir)
+            -b|--build-dir)
                 shift
                 if [[ "$1" != -* ]]; then
                     case $1 in
@@ -140,7 +140,7 @@ function parse_args {
                     exit 3
                 fi
                 ;;
-            --parallel-jobs)
+            -j|--parallel-jobs)
                 shift
                 if [[ "$1" != -* ]]; then
                     jobs=$1
@@ -155,7 +155,7 @@ function parse_args {
                 echo "Please re-run with correct argument name"
                 exit 3
                 ;;
-            --verbosity)
+            -v|--verbosity)
                 shift
                 if [[ "$1" != -* ]]; then
                     verbosity=$1
@@ -182,13 +182,13 @@ function parse_args {
                     exit 3
                 fi
                 ;;
-            --skip)
+            -s|--skip)
                 shift
                 if [[ "$1" != -* ]]; then
                     coin_skip_projects=$1
                 fi
                 ;;
-            --help)
+            -h|--help)
                 help
                 exit 0
                 ;;
@@ -201,13 +201,13 @@ function parse_args {
             --git)
                 VCS=git
                 ;;
-            --debug)
+            -d|--debug)
                 set -x
                 ;;
-            --reconfigure)
+            -r|--reconfigure)
                 reconfigure=true
                 ;;
-            --test)
+            -t|--test)
                 run_test=true
                 ;;
             --test-all)
@@ -216,7 +216,7 @@ function parse_args {
             --no-third-party)
                 get_third_party=false
                 ;;
-            --no-prompt)
+            -n|--no-prompt)
                 no_prompt=true
                 ;;
             --skip-update)

--- a/coinbrew
+++ b/coinbrew
@@ -103,101 +103,90 @@ function get_project {
 
 # Parse arguments
 function parse_args {
-    echo "Script run with the following arguments:"
-    for arg in "$@"
+    while (( "$#" ))
     do
-        echo $arg
-        option=
-        option_arg=
-        case $arg in
-            *=*)
-                option=`expr "x$arg" : 'x\(.*\)=[^=]*'`
-                option_arg=`expr "x$arg" : 'x[^=]*=\(.*\)'`
-                # with bash, one could also do it in the following way:
-                # option=${arg%%=*}    # remove longest suffix matching =*
-                # option_arg=${arg#*=} # remove shortest prefix matching *=
-                case $option in
-                    --prefix)
-                        if [ "x$option_arg" != x ]; then
-                            case $option_arg in
-                                [\\/$]* | ?:[\\/]* | NONE | '' )
-                                    prefix=$option_arg
-                                    ;;
-                                *)  
-                                    echo "Prefix path must be absolute."
-                                    exit 3
-                                    ;;
-                            esac
-                        else
-                            echo "No path provided for --prefix"
+        echo $1
+        case $1 in
+            --prefix)
+                shift
+                if [[ "$1" != -* ]]; then
+                    case $1 in
+                        [\\/$]* | ?:[\\/]* | NONE | '' )
+                            prefix=$1
+                            ;;
+                        *)  
+                            echo "Prefix path must be absolute."
                             exit 3
-                        fi
-                        ;;
-                    --build-dir)
-                        if [ "x$option_arg" != x ]; then
-                            case $option_arg in
-                                [\\/$]* | ?:[\\/]* | NONE | '' )
-                                    build_dir=$option_arg
-                                    ;;
-                                *)
-                                    build_dir=$PWD/$option_arg
-                                    ;;
-                            esac
-                        else
-                            echo "No path provided for --build-dir"
-                            exit 3
-                        fi
-                        ;;
-                    --parallel-jobs)
-                        if [ "x$option_arg" != x ]; then
-                            jobs=$option_arg
-                        else
-                            echo "No number specified for --parallel-jobs"
-                            exit 3
-                        fi
-                        ;;
-                    --threads)
-                        echo "The 'threads' argument has been re-named 'parallel-jobs'."
-                        echo "Please re-run with correct argument name"
-                        exit 3
-                        ;;
-                    --verbosity)
-                        if [ "x$option_arg" != x ]; then
-                            verbosity=$option_arg
-                        else
-                            echo "No verbosity specified for --verbosity"
-                            exit 3
-                        fi
-                        ;;
-                    --main-proj)
-                        if [ "x$option_arg" != x ]; then
-                            main_proj=$option_arg
-                        else
-                            echo "No main project specified"
-                            exit 3
-                        fi
-                        ;;
-                    --main-proj-version)
-                        if [ "x$option_arg" != x ]; then
-                            main_proj_version=$option_arg
-                        else
-                            echo "No main project specified"
-                            exit 3
-                        fi
-                        ;;
-                    DESTDIR)
-                        echo "DESTDIR installation not supported"
-                        exit 3
-                        ;;
-                    --skip)
-                        if [ "x$option_arg" != x ]; then
-                            coin_skip_projects=$option_arg
-                        fi
-                        ;;
-                    *)
-                        configure_options["$arg"]=""
-                        ;;            
-                esac
+                            ;;
+                    esac
+                else
+                    echo "No path provided for --prefix"
+                    exit 3
+                fi
+                ;;
+            --build-dir)
+                shift
+                if [[ "$1" != -* ]]; then
+                    case $1 in
+                        [\\/$]* | ?:[\\/]* | NONE | '' )
+                            build_dir=$1
+                            ;;
+                        *)
+                            build_dir=$PWD/$1
+                            ;;
+                    esac
+                else
+                    echo "No path provided for --build-dir"
+                    exit 3
+                fi
+                ;;
+            --parallel-jobs)
+                shift
+                if [[ "$1" != -* ]]; then
+                    jobs=$1
+                else
+                    echo "No number specified for --parallel-jobs"
+                    exit 3
+                fi
+                ;;
+            --threads)
+                shift
+                echo "The 'threads' argument has been re-named 'parallel-jobs'."
+                echo "Please re-run with correct argument name"
+                exit 3
+                ;;
+            --verbosity)
+                shift
+                if [[ "$1" != -* ]]; then
+                    verbosity=$1
+                else
+                    echo "No verbosity specified for --verbosity"
+                    exit 3
+                fi
+                ;;
+            --main-proj)
+                shift
+                if [[ "$1" != -* ]]; then
+                    main_proj=$1
+                else
+                    echo "No main project specified"
+                    exit 3
+                fi
+                ;;
+            --main-proj-version)
+                shift
+                if [[ "$1" != -* ]]; then
+                    main_proj_version=$1
+                else
+                    echo "No main project specified"
+                    exit 3
+                fi
+                ;;
+            --skip)
+                shift
+                if [[ "$1" != -* ]]; then
+                    coin_skip_projects=$1
+                fi
                 ;;
             --help)
                 help
@@ -234,7 +223,7 @@ function parse_args {
                 skip_update=true
                 ;;
             --*)
-                configure_options["$arg"]=""
+                configure_options["$1"]=""
                 ;;
             fetch)
                 num_actions+=1
@@ -253,10 +242,16 @@ function parse_args {
                 uninstall=true
                 ;;
             *)
-                echo "Unrecognized command...exiting"
-                exit 3
+                if [[ $1 == *:* ]]; then
+                    main_proj=`echo $1 | cut -d ':' -f 1`
+                    main_proj_version=`echo $1 | cut -d ':' -f 2`
+                else
+                    main_proj=$1
+                fi
                 ;;
         esac
+        echo $1
+        shift
     done
     echo
 }

--- a/coinbrew
+++ b/coinbrew
@@ -268,13 +268,11 @@ function parse_args {
             *)
                 if [[ "$arg" == *=* ]] || [[ "$arg" == --* ]]; then
                     configure_options["$arg"]=""
+                elif [[ $arg == *:* ]]; then
+                    main_proj=${arg%%:*}
+                    main_proj_version=${arg#*:}
                 else
-                    if [[ $arg == *:* ]]; then
-                        main_proj=`echo $arg | cut -d ':' -f 1`
-                        main_proj_version=`echo $arg | cut -d ':' -f 2`
-                    else
-                        main_proj=$arg
-                    fi
+                    main_proj=$arg
                 fi
                 ;;
         esac

--- a/coinbrew
+++ b/coinbrew
@@ -105,7 +105,6 @@ function get_project {
 function parse_args {
     while (( "$#" ))
     do
-        echo $1
         case $1 in
             -p|--prefix)
                 shift
@@ -222,7 +221,7 @@ function parse_args {
             --skip-update)
                 skip_update=true
                 ;;
-            --*)
+            --*|*=*)
                 configure_options["$1"]=""
                 ;;
             fetch)
@@ -250,7 +249,6 @@ function parse_args {
                 fi
                 ;;
         esac
-        echo $1
         shift
     done
     echo


### PR DESCRIPTION
OK, I implemented improved option parsing based on my new-found knowledge of the `shift` command. We could get even fancier and go for use of `getopt`, this option parsing does not really error check much. But it seems to work, and it implements what you asked for in #2 and #1. It's easy to add short forms now, too. Maybe I'll do that quickly.