### PR TITLE
Lower case declare optional argument

### DIFF
--- a/coinbrew
+++ b/coinbrew
@@ -915,7 +915,7 @@ install=false
 uninstall=false
 run_test=false
 run_all_tests=false
-declare -A configure_options
+declare -a configure_options
 configure_options=()
 jobs=1
 build_dir=


### PR DESCRIPTION
The script was failing locally and it fixed the issue.
[The bash doc](https://ss64.com/bash/declare.html)