### PR TITLE
Don't overwrite LD_LIBRARY_PATH variable

### DIFF
--- a/coinbrew
+++ b/coinbrew
@@ -1158,7 +1158,7 @@ function build_proj {
            ([ $run_tests = "main" ] && [ x$main_proj != x ] && [ $main_proj_dir = $dir ]); then
         print_action "Running $dir unit test"
         # Fix for systems where the unit test doesn't seem to run with specifying LD_LIBRARY_PATH
-        export LD_LIBRARY_PATH=$prefix/lib
+        export LD_LIBRARY_PATH=$prefix/lib:$LD_LIBRARY_PATH
         if [ $verbosity -ge 2 ]; then
             if [ x$main_proj != x ] && [ $main_proj_dir = $dir ]; then
                 invoke_make $((verbosity+1)) test


### PR DESCRIPTION
Breaking people's preexisting setup is easily avoided by appending to LD_LIBRARY_PATH instead of overwriting it.
In my case, this caused my linker to fail finding my OpenBLAS installation in /opt/OpenBLAS causing the unit tests at the end of the Ipopt installation to fail.