### PR TITLE
Default branch instead of "master"

### DIFF
--- a/coinbrew
+++ b/coinbrew
@@ -1157,7 +1157,7 @@ function fetch_proj {
                 fi
             fi
         fi
-        if [ $keep_current = "true" ]; then
+        if [ $keep_current = "true" ] || [ $version = "master" ]; then
             version=$current_version
         fi
         if ([[ $version != *$current_version ]] &&

--- a/coinbrew
+++ b/coinbrew
@@ -1250,6 +1250,7 @@ function fetch_proj {
                     git clone $url $dir
                 else
                     git clone --branch=$version $url $dir
+                fi
             else
                 print_action "Fetching $dir SHA $sha"
                 git clone $url $dir

--- a/coinbrew
+++ b/coinbrew
@@ -1246,7 +1246,10 @@ function fetch_proj {
         else
             if [ "$sha" = "" ]; then
                 print_action "Fetching $dir $version"
-                git clone --branch=$version $url $dir
+                if [ "$version" = "master" ]; then
+                    git clone $url $dir
+                else
+                    git clone --branch=$version $url $dir
             else
                 print_action "Fetching $dir SHA $sha"
                 git clone $url $dir


### PR DESCRIPTION
Some repos default branch are not named "master" so cloning fails if we select branch "master" If "master" is wished, clone should be done without branch selection, so the default branch is selected.